### PR TITLE
Enable use of a local part suffix.

### DIFF
--- a/lmtp-proxy
+++ b/lmtp-proxy
@@ -108,10 +108,12 @@ class LMTPProxy(LMTPServer):
       return error
 
   def process_message(self, peer, mailfrom, rcptto, data):
+    local_part_suffix = self.config['config'].get('localPartSuffix', False)
+    user = rcptto
+    if local_part_suffix:
+      user = '{}@{}'.format(user.split(local_part_suffix)[0], user.split('@')[1])
     if self.config['config'].get('ignoreDomain', False):
-      user = rcptto.split('@')[0]
-    else:
-      user = rcptto
+      user = user.split('@')[0]
 
     backend = self.lookup_user_backend(user)
 

--- a/lmtp-proxy.conf
+++ b/lmtp-proxy.conf
@@ -14,6 +14,9 @@ config:
   ignoreDomain: True
   fallback_backend: cyrus-unix
   pid: /var/run/lmtp-proxy.pid
+  # Want to use plus sign as a local part suffix, so that
+  # mail sent to user+alias@domain.com are sent to user@domain.com
+  # localPartSuffix: +
 
 backends:
   cyrus-unix:


### PR DESCRIPTION
It aims to enable local part suffix feature.
This is something that can be activated in several SMTP server (such as exim) or IMAP server (such as dovecot).